### PR TITLE
Add PHP SQLite CRM with authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+database/*.sqlite
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # Funnel
-A lightweight, SQLite-powered CRM for managing contacts, deals, and activities. Simple, fast, and built for sales pipelines.
+
+Funnel is a lightweight CRM built with PHP and SQLite. It lets small teams manage companies, contacts, deals, and sales activities with a minimalist, mobile-responsive interface.
+
+## Features
+
+* User registration, login, and secure password storage.
+* Company, contact, deal, and activity tracking backed by SQLite.
+* Inline stage management and automatic deal assignment to the creator.
+* Clean, responsive UI designed to work well on desktops and phones.
+
+## Getting started
+
+1. **Install PHP** (8.1+ recommended) with the SQLite extension enabled.
+2. **Start the built-in server** from the project root:
+
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+
+3. **Open the app** in your browser at [http://localhost:8000](http://localhost:8000).
+
+On first run, the SQLite database is created automatically in `database/crm.sqlite`. Create an account from the landing page and start logging companies, contacts, deals, and activities.

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/db.php';
+
+function register_user(PDO $pdo, string $username, string $password, ?string $fullName, ?string $email, string $role = 'sales'): array
+{
+    $errors = [];
+
+    if (trim($username) === '') {
+        $errors[] = 'Username is required.';
+    }
+
+    if (strlen($password) < 6) {
+        $errors[] = 'Password must be at least 6 characters.';
+    }
+
+    if (!in_array($role, ['admin', 'manager', 'sales'], true)) {
+        $role = 'sales';
+    }
+
+    if ($errors) {
+        return $errors;
+    }
+
+    try {
+        $stmt = $pdo->prepare('INSERT INTO users (username, password, full_name, email, role) VALUES (:username, :password, :full_name, :email, :role)');
+        $stmt->execute([
+            ':username' => strtolower(trim($username)),
+            ':password' => password_hash($password, PASSWORD_DEFAULT),
+            ':full_name' => $fullName ? trim($fullName) : null,
+            ':email' => $email ? strtolower(trim($email)) : null,
+            ':role' => $role,
+        ]);
+    } catch (PDOException $e) {
+        if (str_contains($e->getMessage(), 'UNIQUE')) {
+            $errors[] = 'Username or email already exists.';
+        } else {
+            $errors[] = 'Unable to create user: ' . $e->getMessage();
+        }
+    }
+
+    return $errors;
+}
+
+function authenticate_user(PDO $pdo, string $username, string $password): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = :username LIMIT 1');
+    $stmt->execute([':username' => strtolower(trim($username))]);
+    $user = $stmt->fetch();
+
+    if ($user && password_verify($password, $user['password'])) {
+        return $user;
+    }
+
+    return null;
+}
+
+function get_user_by_id(PDO $pdo, int $userId): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE user_id = :id');
+    $stmt->execute([':id' => $userId]);
+    $user = $stmt->fetch();
+
+    return $user ?: null;
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+function get_database_connection(): PDO
+{
+    $dbPath = __DIR__ . '/../database/crm.sqlite';
+    $needsInitialization = !file_exists($dbPath);
+
+    $pdo = new PDO('sqlite:' . $dbPath);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+
+    if ($needsInitialization) {
+        initialize_schema($pdo);
+    } else {
+        // Ensure schema exists when database file is present but tables are missing.
+        initialize_schema($pdo);
+    }
+
+    return $pdo;
+}
+
+function initialize_schema(PDO $pdo): void
+{
+    $statements = [
+        "CREATE TABLE IF NOT EXISTS users (
+            user_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            username    TEXT UNIQUE NOT NULL,
+            password    TEXT NOT NULL,
+            full_name   TEXT,
+            email       TEXT UNIQUE,
+            role        TEXT CHECK(role IN ('admin', 'manager', 'sales')) DEFAULT 'sales',
+            created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+        )",
+        "CREATE TABLE IF NOT EXISTS companies (
+            company_id  INTEGER PRIMARY KEY AUTOINCREMENT,
+            name        TEXT NOT NULL,
+            industry    TEXT,
+            website     TEXT,
+            phone       TEXT,
+            created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+        )",
+        "CREATE TABLE IF NOT EXISTS contacts (
+            contact_id  INTEGER PRIMARY KEY AUTOINCREMENT,
+            company_id  INTEGER,
+            first_name  TEXT NOT NULL,
+            last_name   TEXT NOT NULL,
+            email       TEXT UNIQUE,
+            phone       TEXT,
+            position    TEXT,
+            created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (company_id) REFERENCES companies(company_id) ON DELETE SET NULL
+        )",
+        "CREATE TABLE IF NOT EXISTS deals (
+            deal_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            company_id  INTEGER,
+            contact_id  INTEGER,
+            name        TEXT NOT NULL,
+            stage       TEXT CHECK(stage IN ('lead', 'qualified', 'proposal', 'negotiation', 'closed_won', 'closed_lost')),
+            value       REAL,
+            close_date  DATE,
+            created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (company_id) REFERENCES companies(company_id) ON DELETE SET NULL,
+            FOREIGN KEY (contact_id) REFERENCES contacts(contact_id) ON DELETE SET NULL
+        )",
+        "CREATE TABLE IF NOT EXISTS activities (
+            activity_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            deal_id     INTEGER,
+            contact_id  INTEGER,
+            type        TEXT CHECK(type IN ('call', 'email', 'meeting', 'note')),
+            subject     TEXT,
+            content     TEXT,
+            activity_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (deal_id) REFERENCES deals(deal_id) ON DELETE CASCADE,
+            FOREIGN KEY (contact_id) REFERENCES contacts(contact_id) ON DELETE SET NULL
+        )",
+        "CREATE TABLE IF NOT EXISTS deal_assignments (
+            deal_id INTEGER,
+            user_id INTEGER,
+            PRIMARY KEY (deal_id, user_id),
+            FOREIGN KEY (deal_id) REFERENCES deals(deal_id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+        )"
+    ];
+
+    foreach ($statements as $sql) {
+        $pdo->exec($sql);
+    }
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+function e(?string $value): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+function redirect(string $path): void
+{
+    header('Location: ' . $path);
+    exit;
+}
+
+function require_login(): void
+{
+    if (empty($_SESSION['user_id'])) {
+        redirect('index.php');
+    }
+}
+
+function set_flash(string $message, string $type = 'success'): void
+{
+    $_SESSION['flash'] = ['message' => $message, 'type' => $type];
+}
+
+function get_flash(): ?array
+{
+    if (!empty($_SESSION['flash'])) {
+        $flash = $_SESSION['flash'];
+        unset($_SESSION['flash']);
+        return $flash;
+    }
+
+    return null;
+}

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,0 +1,305 @@
+:root {
+    --bg: #f9fafb;
+    --card-bg: #ffffff;
+    --border: #e5e7eb;
+    --text: #1f2933;
+    --muted: #6b7280;
+    --accent: #2563eb;
+    --accent-soft: rgba(37, 99, 235, 0.12);
+    --error: #dc2626;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+}
+
+.layout {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--card-bg);
+}
+
+.top-bar h1 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.user-info {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    font-size: 0.95rem;
+}
+
+.user-info form {
+    margin: 0;
+}
+
+.content {
+    flex: 1;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.auth-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.card h2 {
+    margin-top: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.metric {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.metric-label {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.metric-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+.tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    background: transparent;
+}
+
+.tabs a {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.tabs a.active,
+.tabs a:hover {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent);
+}
+
+.split {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.table {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.table-head,
+.table-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    align-items: center;
+}
+
+.table-head {
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.table-row {
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: #fff;
+}
+
+.table-row.muted {
+    color: var(--muted);
+    justify-content: center;
+    text-align: center;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.form-grid label {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+}
+
+input, select, textarea, button {
+    font: inherit;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="url"],
+input[type="date"],
+input[type="datetime-local"],
+select,
+textarea {
+    padding: 0.65rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+button {
+    padding: 0.65rem 1rem;
+    border-radius: 8px;
+    border: none;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+    background: #1d4ed8;
+}
+
+button:active {
+    transform: translateY(1px);
+}
+
+button.link {
+    background: transparent;
+    color: var(--accent);
+    padding: 0;
+}
+
+.alert {
+    padding: 0.85rem 1rem;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    font-size: 0.95rem;
+}
+
+.alert.success {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgba(34, 197, 94, 0.2);
+    color: #15803d;
+}
+
+.alert.error {
+    background: rgba(220, 38, 38, 0.08);
+    border-color: rgba(220, 38, 38, 0.3);
+    color: var(--error);
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.8rem;
+    text-transform: capitalize;
+}
+
+.inline-form {
+    display: inline-flex;
+    align-items: center;
+}
+
+.inline-form select {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.85rem;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border);
+    background: var(--card-bg);
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 640px) {
+    .top-bar {
+        flex-direction: column;
+        gap: 0.75rem;
+        align-items: flex-start;
+    }
+
+    .tabs {
+        gap: 0.5rem;
+    }
+
+    .table-head,
+    .table-row {
+        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        font-size: 0.85rem;
+    }
+
+    .content {
+        padding: 1rem;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,623 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/helpers.php';
+
+$pdo = get_database_connection();
+$currentUser = null;
+$errors = [];
+
+if (!empty($_SESSION['user_id'])) {
+    $currentUser = get_user_by_id($pdo, (int) $_SESSION['user_id']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    switch ($action) {
+        case 'login':
+            $username = $_POST['username'] ?? '';
+            $password = $_POST['password'] ?? '';
+            $user = authenticate_user($pdo, $username, $password);
+
+            if ($user) {
+                $_SESSION['user_id'] = (int) $user['user_id'];
+                set_flash('Welcome back, ' . ($user['full_name'] ?: $user['username']) . '!');
+                redirect('index.php');
+            } else {
+                $errors[] = 'Invalid username or password.';
+            }
+            break;
+        case 'register':
+            $username = $_POST['username'] ?? '';
+            $password = $_POST['password'] ?? '';
+            $fullName = $_POST['full_name'] ?? null;
+            $email = $_POST['email'] ?? null;
+            $role = $_POST['role'] ?? 'sales';
+
+            $errors = register_user($pdo, $username, $password, $fullName, $email, $role);
+            if (!$errors) {
+                set_flash('Account created. You can now log in.');
+                redirect('index.php');
+            }
+            break;
+        case 'logout':
+            session_destroy();
+            redirect('index.php');
+            break;
+        case 'add_company':
+            require_login();
+            $name = trim($_POST['name'] ?? '');
+            $industry = trim($_POST['industry'] ?? '');
+            $website = trim($_POST['website'] ?? '');
+            $phone = trim($_POST['phone'] ?? '');
+
+            if ($name === '') {
+                set_flash('Company name is required.', 'error');
+                redirect('index.php?view=companies');
+            }
+
+            $stmt = $pdo->prepare('INSERT INTO companies (name, industry, website, phone) VALUES (:name, :industry, :website, :phone)');
+            $stmt->execute([
+                ':name' => $name,
+                ':industry' => $industry ?: null,
+                ':website' => $website ?: null,
+                ':phone' => $phone ?: null,
+            ]);
+
+            set_flash('Company created successfully.');
+            redirect('index.php?view=companies');
+            break;
+        case 'add_contact':
+            require_login();
+            $firstName = trim($_POST['first_name'] ?? '');
+            $lastName = trim($_POST['last_name'] ?? '');
+            $email = trim($_POST['email'] ?? '');
+            $phone = trim($_POST['phone'] ?? '');
+            $position = trim($_POST['position'] ?? '');
+            $companyId = isset($_POST['company_id']) && $_POST['company_id'] !== '' ? (int) $_POST['company_id'] : null;
+
+            if ($firstName === '' || $lastName === '') {
+                set_flash('First and last name are required for contacts.', 'error');
+                redirect('index.php?view=contacts');
+            }
+
+            try {
+                $stmt = $pdo->prepare('INSERT INTO contacts (company_id, first_name, last_name, email, phone, position) VALUES (:company_id, :first_name, :last_name, :email, :phone, :position)');
+                $stmt->execute([
+                    ':company_id' => $companyId,
+                    ':first_name' => $firstName,
+                    ':last_name' => $lastName,
+                    ':email' => $email ?: null,
+                    ':phone' => $phone ?: null,
+                    ':position' => $position ?: null,
+                ]);
+                set_flash('Contact saved successfully.');
+            } catch (PDOException $e) {
+                set_flash('Unable to save contact: ' . $e->getMessage(), 'error');
+            }
+
+            redirect('index.php?view=contacts');
+            break;
+        case 'add_deal':
+            require_login();
+            $name = trim($_POST['name'] ?? '');
+            $stage = $_POST['stage'] ?? 'lead';
+            $value = $_POST['value'] !== '' ? (float) $_POST['value'] : null;
+            $closeDate = $_POST['close_date'] ?? null;
+            $companyId = isset($_POST['company_id']) && $_POST['company_id'] !== '' ? (int) $_POST['company_id'] : null;
+            $contactId = isset($_POST['contact_id']) && $_POST['contact_id'] !== '' ? (int) $_POST['contact_id'] : null;
+
+            if ($name === '') {
+                set_flash('Deal name is required.', 'error');
+                redirect('index.php?view=deals');
+            }
+
+            $stmt = $pdo->prepare('INSERT INTO deals (company_id, contact_id, name, stage, value, close_date) VALUES (:company_id, :contact_id, :name, :stage, :value, :close_date)');
+            $stmt->execute([
+                ':company_id' => $companyId,
+                ':contact_id' => $contactId,
+                ':name' => $name,
+                ':stage' => $stage,
+                ':value' => $value,
+                ':close_date' => $closeDate ?: null,
+            ]);
+
+            $dealId = (int) $pdo->lastInsertId();
+            if (!empty($_SESSION['user_id'])) {
+                $assign = $pdo->prepare('INSERT OR IGNORE INTO deal_assignments (deal_id, user_id) VALUES (:deal_id, :user_id)');
+                $assign->execute([
+                    ':deal_id' => $dealId,
+                    ':user_id' => (int) $_SESSION['user_id'],
+                ]);
+            }
+
+            set_flash('Deal created successfully.');
+            redirect('index.php?view=deals');
+            break;
+        case 'update_deal_stage':
+            require_login();
+            $dealId = (int) ($_POST['deal_id'] ?? 0);
+            $stage = $_POST['stage'] ?? 'lead';
+
+            $stmt = $pdo->prepare('UPDATE deals SET stage = :stage WHERE deal_id = :deal_id');
+            $stmt->execute([
+                ':stage' => $stage,
+                ':deal_id' => $dealId,
+            ]);
+
+            set_flash('Deal stage updated.');
+            redirect('index.php?view=deals');
+            break;
+        case 'add_activity':
+            require_login();
+            $type = $_POST['type'] ?? 'note';
+            $subject = trim($_POST['subject'] ?? '');
+            $content = trim($_POST['content'] ?? '');
+            $dealId = isset($_POST['deal_id']) && $_POST['deal_id'] !== '' ? (int) $_POST['deal_id'] : null;
+            $contactId = isset($_POST['contact_id']) && $_POST['contact_id'] !== '' ? (int) $_POST['contact_id'] : null;
+            $activityDate = $_POST['activity_date'] ?? null;
+
+            $stmt = $pdo->prepare('INSERT INTO activities (deal_id, contact_id, type, subject, content, activity_date) VALUES (:deal_id, :contact_id, :type, :subject, :content, COALESCE(:activity_date, CURRENT_TIMESTAMP))');
+            $stmt->execute([
+                ':deal_id' => $dealId,
+                ':contact_id' => $contactId,
+                ':type' => $type,
+                ':subject' => $subject ?: null,
+                ':content' => $content ?: null,
+                ':activity_date' => $activityDate ?: null,
+            ]);
+
+            set_flash('Activity logged.');
+            redirect('index.php?view=activities');
+            break;
+        default:
+            break;
+    }
+}
+
+$flash = get_flash();
+$view = $_GET['view'] ?? 'dashboard';
+
+if ($currentUser) {
+    $dashboardStats = [
+        'companies' => (int) $pdo->query('SELECT COUNT(*) FROM companies')->fetchColumn(),
+        'contacts' => (int) $pdo->query('SELECT COUNT(*) FROM contacts')->fetchColumn(),
+        'deals' => (int) $pdo->query('SELECT COUNT(*) FROM deals')->fetchColumn(),
+        'activities' => (int) $pdo->query('SELECT COUNT(*) FROM activities')->fetchColumn(),
+    ];
+
+    $companies = $pdo->query('SELECT * FROM companies ORDER BY created_at DESC')->fetchAll();
+    $contacts = $pdo->query('SELECT contacts.*, companies.name AS company_name FROM contacts LEFT JOIN companies ON contacts.company_id = companies.company_id ORDER BY contacts.created_at DESC')->fetchAll();
+    $deals = $pdo->query("SELECT deals.*, companies.name AS company_name, contacts.first_name, contacts.last_name, GROUP_CONCAT(COALESCE(users.full_name, users.username), ', ') AS assigned_users
+        FROM deals
+        LEFT JOIN companies ON deals.company_id = companies.company_id
+        LEFT JOIN contacts ON deals.contact_id = contacts.contact_id
+        LEFT JOIN deal_assignments ON deals.deal_id = deal_assignments.deal_id
+        LEFT JOIN users ON deal_assignments.user_id = users.user_id
+        GROUP BY deals.deal_id
+        ORDER BY deals.created_at DESC")->fetchAll();
+    $activities = $pdo->query("SELECT activities.*, deals.name AS deal_name, contacts.first_name, contacts.last_name
+        FROM activities
+        LEFT JOIN deals ON activities.deal_id = deals.deal_id
+        LEFT JOIN contacts ON activities.contact_id = contacts.contact_id
+        ORDER BY activities.activity_date DESC")->fetchAll();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funnel CRM</title>
+    <link rel="stylesheet" href="assets/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="layout">
+        <header class="top-bar">
+            <h1>Funnel CRM</h1>
+            <?php if ($currentUser): ?>
+                <div class="user-info">
+                    <span><?= e($currentUser['full_name'] ?: $currentUser['username']) ?></span>
+                    <form method="post">
+                        <input type="hidden" name="action" value="logout">
+                        <button type="submit" class="link">Log out</button>
+                    </form>
+                </div>
+            <?php endif; ?>
+        </header>
+
+        <main class="content">
+            <?php if ($flash): ?>
+                <div class="alert <?= e($flash['type']) ?>"><?= e($flash['message']) ?></div>
+            <?php endif; ?>
+
+            <?php if ($errors): ?>
+                <div class="alert error">
+                    <?php foreach ($errors as $error): ?>
+                        <div><?= e($error) ?></div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!$currentUser): ?>
+                <section class="auth-grid">
+                    <div class="card">
+                        <h2>Sign in</h2>
+                        <form method="post" class="form-grid">
+                            <input type="hidden" name="action" value="login">
+                            <label>
+                                <span>Username</span>
+                                <input type="text" name="username" required>
+                            </label>
+                            <label>
+                                <span>Password</span>
+                                <input type="password" name="password" required>
+                            </label>
+                            <button type="submit">Sign in</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <h2>Create account</h2>
+                        <form method="post" class="form-grid">
+                            <input type="hidden" name="action" value="register">
+                            <label>
+                                <span>Full name</span>
+                                <input type="text" name="full_name">
+                            </label>
+                            <label>
+                                <span>Email</span>
+                                <input type="email" name="email">
+                            </label>
+                            <label>
+                                <span>Username</span>
+                                <input type="text" name="username" required>
+                            </label>
+                            <label>
+                                <span>Password</span>
+                                <input type="password" name="password" required>
+                            </label>
+                            <label>
+                                <span>Role</span>
+                                <select name="role">
+                                    <option value="sales">Sales</option>
+                                    <option value="manager">Manager</option>
+                                    <option value="admin">Admin</option>
+                                </select>
+                            </label>
+                            <button type="submit">Register</button>
+                        </form>
+                    </div>
+                </section>
+            <?php else: ?>
+                <nav class="tabs">
+                    <a href="?view=dashboard" class="<?= $view === 'dashboard' ? 'active' : '' ?>">Dashboard</a>
+                    <a href="?view=companies" class="<?= $view === 'companies' ? 'active' : '' ?>">Companies</a>
+                    <a href="?view=contacts" class="<?= $view === 'contacts' ? 'active' : '' ?>">Contacts</a>
+                    <a href="?view=deals" class="<?= $view === 'deals' ? 'active' : '' ?>">Deals</a>
+                    <a href="?view=activities" class="<?= $view === 'activities' ? 'active' : '' ?>">Activities</a>
+                </nav>
+
+                <?php if ($view === 'dashboard'): ?>
+                    <section class="cards-grid">
+                        <div class="card metric">
+                            <span class="metric-label">Companies</span>
+                            <span class="metric-value"><?= $dashboardStats['companies'] ?></span>
+                        </div>
+                        <div class="card metric">
+                            <span class="metric-label">Contacts</span>
+                            <span class="metric-value"><?= $dashboardStats['contacts'] ?></span>
+                        </div>
+                        <div class="card metric">
+                            <span class="metric-label">Deals</span>
+                            <span class="metric-value"><?= $dashboardStats['deals'] ?></span>
+                        </div>
+                        <div class="card metric">
+                            <span class="metric-label">Activities</span>
+                            <span class="metric-value"><?= $dashboardStats['activities'] ?></span>
+                        </div>
+                    </section>
+                    <section class="card">
+                        <h2>Recent deals</h2>
+                        <div class="table">
+                            <div class="table-head">
+                                <span>Name</span>
+                                <span>Company</span>
+                                <span>Stage</span>
+                                <span>Value</span>
+                            </div>
+                            <?php foreach (array_slice($deals, 0, 5) as $deal): ?>
+                                <div class="table-row">
+                                    <span><?= e($deal['name']) ?></span>
+                                    <span><?= e($deal['company_name'] ?? '—') ?></span>
+                                    <span class="pill"><?= e($deal['stage']) ?></span>
+                                    <span><?= $deal['value'] ? '$' . number_format((float) $deal['value'], 2) : '—' ?></span>
+                                </div>
+                            <?php endforeach; ?>
+                            <?php if (!$deals): ?>
+                                <div class="table-row muted">No deals yet.</div>
+                            <?php endif; ?>
+                        </div>
+                    </section>
+                <?php elseif ($view === 'companies'): ?>
+                    <section class="split">
+                        <div class="card">
+                            <h2>Companies</h2>
+                            <div class="table">
+                                <div class="table-head">
+                                    <span>Name</span>
+                                    <span>Industry</span>
+                                    <span>Phone</span>
+                                </div>
+                                <?php foreach ($companies as $company): ?>
+                                    <div class="table-row">
+                                        <span><?= e($company['name']) ?></span>
+                                        <span><?= e($company['industry'] ?? '—') ?></span>
+                                        <span><?= e($company['phone'] ?? '—') ?></span>
+                                    </div>
+                                <?php endforeach; ?>
+                                <?php if (!$companies): ?>
+                                    <div class="table-row muted">No companies yet.</div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <h2>Add company</h2>
+                            <form method="post" class="form-grid">
+                                <input type="hidden" name="action" value="add_company">
+                                <label>
+                                    <span>Name</span>
+                                    <input type="text" name="name" required>
+                                </label>
+                                <label>
+                                    <span>Industry</span>
+                                    <input type="text" name="industry">
+                                </label>
+                                <label>
+                                    <span>Website</span>
+                                    <input type="url" name="website">
+                                </label>
+                                <label>
+                                    <span>Phone</span>
+                                    <input type="text" name="phone">
+                                </label>
+                                <button type="submit">Create</button>
+                            </form>
+                        </div>
+                    </section>
+                <?php elseif ($view === 'contacts'): ?>
+                    <section class="split">
+                        <div class="card">
+                            <h2>Contacts</h2>
+                            <div class="table">
+                                <div class="table-head">
+                                    <span>Name</span>
+                                    <span>Company</span>
+                                    <span>Email</span>
+                                    <span>Phone</span>
+                                </div>
+                                <?php foreach ($contacts as $contact): ?>
+                                    <div class="table-row">
+                                        <span><?= e($contact['first_name'] . ' ' . $contact['last_name']) ?></span>
+                                        <span><?= e($contact['company_name'] ?? '—') ?></span>
+                                        <span><?= e($contact['email'] ?? '—') ?></span>
+                                        <span><?= e($contact['phone'] ?? '—') ?></span>
+                                    </div>
+                                <?php endforeach; ?>
+                                <?php if (!$contacts): ?>
+                                    <div class="table-row muted">No contacts yet.</div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <h2>Add contact</h2>
+                            <form method="post" class="form-grid">
+                                <input type="hidden" name="action" value="add_contact">
+                                <label>
+                                    <span>First name</span>
+                                    <input type="text" name="first_name" required>
+                                </label>
+                                <label>
+                                    <span>Last name</span>
+                                    <input type="text" name="last_name" required>
+                                </label>
+                                <label>
+                                    <span>Email</span>
+                                    <input type="email" name="email">
+                                </label>
+                                <label>
+                                    <span>Phone</span>
+                                    <input type="text" name="phone">
+                                </label>
+                                <label>
+                                    <span>Position</span>
+                                    <input type="text" name="position">
+                                </label>
+                                <label>
+                                    <span>Company</span>
+                                    <select name="company_id">
+                                        <option value="">Unassigned</option>
+                                        <?php foreach ($companies as $company): ?>
+                                            <option value="<?= $company['company_id'] ?>"><?= e($company['name']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <button type="submit">Save</button>
+                            </form>
+                        </div>
+                    </section>
+                <?php elseif ($view === 'deals'): ?>
+                    <section class="split">
+                        <div class="card">
+                            <h2>Deals</h2>
+                            <div class="table">
+                                <div class="table-head">
+                                    <span>Name</span>
+                                    <span>Company</span>
+                                    <span>Stage</span>
+                                    <span>Value</span>
+                                    <span>Assigned</span>
+                                </div>
+                                <?php foreach ($deals as $deal): ?>
+                                    <div class="table-row">
+                                        <span><?= e($deal['name']) ?></span>
+                                        <span><?= e($deal['company_name'] ?? '—') ?></span>
+                                        <span>
+                                            <form method="post" class="inline-form">
+                                                <input type="hidden" name="action" value="update_deal_stage">
+                                                <input type="hidden" name="deal_id" value="<?= $deal['deal_id'] ?>">
+                                                <select name="stage" onchange="this.form.submit()">
+                                                    <?php foreach (['lead','qualified','proposal','negotiation','closed_won','closed_lost'] as $stageOption): ?>
+                                                        <option value="<?= $stageOption ?>" <?= $deal['stage'] === $stageOption ? 'selected' : '' ?>><?= ucfirst(str_replace('_', ' ', $stageOption)) ?></option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </form>
+                                        </span>
+                                        <span><?= $deal['value'] ? '$' . number_format((float) $deal['value'], 2) : '—' ?></span>
+                                        <span><?= $deal['assigned_users'] ? e($deal['assigned_users']) : '—' ?></span>
+                                    </div>
+                                <?php endforeach; ?>
+                                <?php if (!$deals): ?>
+                                    <div class="table-row muted">No deals yet.</div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <h2>Add deal</h2>
+                            <form method="post" class="form-grid">
+                                <input type="hidden" name="action" value="add_deal">
+                                <label>
+                                    <span>Name</span>
+                                    <input type="text" name="name" required>
+                                </label>
+                                <label>
+                                    <span>Stage</span>
+                                    <select name="stage">
+                                        <?php foreach (['lead','qualified','proposal','negotiation','closed_won','closed_lost'] as $stageOption): ?>
+                                            <option value="<?= $stageOption ?>"><?= ucfirst(str_replace('_', ' ', $stageOption)) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Value</span>
+                                    <input type="number" step="0.01" name="value">
+                                </label>
+                                <label>
+                                    <span>Expected close</span>
+                                    <input type="date" name="close_date">
+                                </label>
+                                <label>
+                                    <span>Company</span>
+                                    <select name="company_id">
+                                        <option value="">Unassigned</option>
+                                        <?php foreach ($companies as $company): ?>
+                                            <option value="<?= $company['company_id'] ?>"><?= e($company['name']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Primary contact</span>
+                                    <select name="contact_id">
+                                        <option value="">Unassigned</option>
+                                        <?php foreach ($contacts as $contact): ?>
+                                            <option value="<?= $contact['contact_id'] ?>"><?= e($contact['first_name'] . ' ' . $contact['last_name']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <button type="submit">Create deal</button>
+                            </form>
+                        </div>
+                    </section>
+                <?php elseif ($view === 'activities'): ?>
+                    <section class="split">
+                        <div class="card">
+                            <h2>Activities</h2>
+                            <div class="table">
+                                <div class="table-head">
+                                    <span>Type</span>
+                                    <span>Subject</span>
+                                    <span>Related to</span>
+                                    <span>Date</span>
+                                </div>
+                                <?php foreach ($activities as $activity): ?>
+                                    <div class="table-row">
+                                        <span class="pill"><?= e($activity['type']) ?></span>
+                                        <span><?= e($activity['subject'] ?? '—') ?></span>
+                                        <span>
+                                            <?php if ($activity['deal_name']): ?>
+                                                <?= e($activity['deal_name']) ?>
+                                            <?php elseif ($activity['first_name']): ?>
+                                                <?= e($activity['first_name'] . ' ' . $activity['last_name']) ?>
+                                            <?php else: ?>
+                                                —
+                                            <?php endif; ?>
+                                        </span>
+                                        <span><?= e(date('Y-m-d H:i', strtotime((string) $activity['activity_date']))) ?></span>
+                                    </div>
+                                <?php endforeach; ?>
+                                <?php if (!$activities): ?>
+                                    <div class="table-row muted">No activities yet.</div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <div class="card">
+                            <h2>Log activity</h2>
+                            <form method="post" class="form-grid">
+                                <input type="hidden" name="action" value="add_activity">
+                                <label>
+                                    <span>Type</span>
+                                    <select name="type">
+                                        <?php foreach (['call','email','meeting','note'] as $typeOption): ?>
+                                            <option value="<?= $typeOption ?>"><?= ucfirst($typeOption) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Subject</span>
+                                    <input type="text" name="subject">
+                                </label>
+                                <label>
+                                    <span>Notes</span>
+                                    <textarea name="content" rows="4"></textarea>
+                                </label>
+                                <label>
+                                    <span>Deal</span>
+                                    <select name="deal_id">
+                                        <option value="">None</option>
+                                        <?php foreach ($deals as $deal): ?>
+                                            <option value="<?= $deal['deal_id'] ?>"><?= e($deal['name']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Contact</span>
+                                    <select name="contact_id">
+                                        <option value="">None</option>
+                                        <?php foreach ($contacts as $contact): ?>
+                                            <option value="<?= $contact['contact_id'] ?>"><?= e($contact['first_name'] . ' ' . $contact['last_name']) ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Date</span>
+                                    <input type="datetime-local" name="activity_date">
+                                </label>
+                                <button type="submit">Log activity</button>
+                            </form>
+                        </div>
+                    </section>
+                <?php endif; ?>
+            <?php endif; ?>
+        </main>
+
+        <footer class="footer">Built with SQLite &amp; PHP</footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a PHP front controller with SQLite-backed models for companies, contacts, deals, and activities
- add session-based authentication with registration, login, and deal assignment to the creator
- design a minimalist responsive UI and document setup instructions for running the CRM locally

## Testing
- php -l public/index.php
- php -l includes/db.php
- php -l includes/auth.php
- php -l includes/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe0cef874832b9aea551c4d68889c